### PR TITLE
Template and component listings on the index are now fully recursive and follow the same logic

### DIFF
--- a/config.js
+++ b/config.js
@@ -44,7 +44,6 @@ module.exports = {
             indexDir: base.docs,
             layoutDir: `${base.docs}/layout`,
             templates: `${base.src}/templates`,
-            templatesAll: `${base.src}/templates/**/**.njk`,
             statics: `${base.docs}/static/**`,
             component: 'component-detail.njk',
             preview: 'component-preview.njk',

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "stylelint-declaration-strict-value": "^1.0.3",
     "stylelint-scss": "^1.4.1",
     "uglify-js": "^2.8.15",
+    "vinyl": "^2.1.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-ftp": "^0.4.5",
     "vinyl-source-stream": "^1.1.0",

--- a/tasks/docs.js
+++ b/tasks/docs.js
@@ -24,8 +24,8 @@ gulp.task('docs-copy-statics', () =>
 gulp.task('docs-render-index', () => {
 
     // Grab list of templates
-    const templates = helpers.getTemplateTree(config.docs.src.templatesAll, config.docs.src.templates);
-    const components = helpers.getComponentTree(config.docs.src.componentsAll, config.docs.src.components);
+    const templates = helpers.getTemplateTree(config.docs.src.templates);
+    const components = helpers.getComponentTree(config.docs.src.components);
 
     // Data
     const data = {

--- a/tasks/docs.js
+++ b/tasks/docs.js
@@ -24,12 +24,12 @@ gulp.task('docs-copy-statics', () =>
 gulp.task('docs-render-index', () => {
 
     // Grab list of templates
-    const templates = helpers.getRelativePaths(config.docs.src.templatesAll, config.docs.src.templates);
+    const templates = helpers.getTemplateTree(config.docs.src.templatesAll, config.docs.src.templates);
     const components = helpers.getComponentTree(config.docs.src.componentsAll, config.docs.src.components);
 
     // Data
     const data = {
-        templates: templates.map(template => template.replace(/[\\]/g, '/')),
+        templates: templates,
         components: components,
         lastUpdated: moment().tz('Europe/Amsterdam').format('DD-MM-YYYY HH:mm:ss z')
     };

--- a/tasks/docs/index.njk
+++ b/tasks/docs/index.njk
@@ -9,13 +9,23 @@
         <!--[[dist.zip]]-->
 
         <h2>Templates</h2>
-        <ol>
-        {%- for tpl in templates %}
-            {%- set name = tpl | replace('.njk', '') %}
-            {%- set name = name | replace( r/[_-]/g, ' ') %}
-            <li><a href="templates/{{ tpl.replace('.njk', '.html') }}">{{ name | replace('/', ' / ') | capitalize }}</a></li>
-        {%- endfor %}
-        </ol>
+        <ul>
+            {% for name, template in templates %}
+                {% if template.variations.length <= 1 %}
+                    {%- set variation = template.variations[0] %}
+                    <li><a href="templates/{{ variation.url.replace('.njk', '.html') }}">{{ variation.name | capitalize }}</a></li>
+                {% else %}
+                    <li class="template-variations">
+                        <strong>{{ name | capitalize }}</strong>
+                        <ul>
+                            {% for variation in template.variations %}
+                            <li><a href="templates/{{ variation.url.replace('.njk', '.html') }}">{{ variation.name | capitalize }}</a></li>
+                            {% endfor %}
+                        </ul>
+                    </li>
+                {% endif %}
+            {% endfor %}
+        </ul>
 
         <h2>Components</h2>
         <ul>

--- a/tasks/docs/index.njk
+++ b/tasks/docs/index.njk
@@ -2,6 +2,24 @@
 
 {%- block body %}
 
+{% macro renderTree(tree) %}
+    <ul>
+    {% for item in tree %}
+        <li>
+        {% if item.url %}
+            <a href="{{ item.url }}">{{ item.name | capitalize }}</a>
+        {% else %}
+            <span>{{ item.name | capitalize }}</span>
+        {% endif %}
+
+        {% if item.branches %}
+            {{ renderTree(item.branches) }}
+        {% endif %}
+        </li>
+    {% endfor %}
+    </ul>
+{% endmacro %}
+
 <div class="container">
 
     <h1>Front-End Library</h1>
@@ -9,42 +27,10 @@
         <!--[[dist.zip]]-->
 
         <h2>Templates</h2>
-        <ul>
-            {% for name, template in templates %}
-                {% if template.variations.length <= 1 %}
-                    {%- set variation = template.variations[0] %}
-                    <li><a href="templates/{{ variation.url.replace('.njk', '.html') }}">{{ variation.name | capitalize }}</a></li>
-                {% else %}
-                    <li class="template-variations">
-                        <strong>{{ name | capitalize }}</strong>
-                        <ul>
-                            {% for variation in template.variations %}
-                            <li><a href="templates/{{ variation.url.replace('.njk', '.html') }}">{{ variation.name | capitalize }}</a></li>
-                            {% endfor %}
-                        </ul>
-                    </li>
-                {% endif %}
-            {% endfor %}
-        </ul>
+        {{ renderTree(templates) }}
 
         <h2>Components</h2>
-        <ul>
-            {% for name, component in components %}
-                {% if component.variations.length <= 1 %}
-                    {%- set variation = component.variations[0] %}
-                    <li><a href="docs/components/{{ variation.url.replace('.njk', '.html') }}">{{ variation.name }}</a></li>
-                {% else %}
-                    <li class="component-variations">
-                        <strong>{{ name }}</strong>
-                        <ul>
-                            {% for variation in component.variations %}
-                                <li><a href="docs/components/{{ variation.url.replace('.njk', '.html') }}">{{ variation.name }}</a></li>
-                            {% endfor %}
-                        </ul>
-                    </li>
-                {% endif %}
-            {% endfor %}
-        </ul>
+        {{ renderTree(components) }}
 
 </div>
 

--- a/tasks/util/docHelpers.js
+++ b/tasks/util/docHelpers.js
@@ -96,6 +96,34 @@ class docsHelpers {
     }
 
     /**
+     * Get the template tree
+     * @param {string} globString - glob pattern for the template files
+     * @param {string} relativeTo - dir containing the files in globString
+     * @returns {Object} tree - object with alle templates and children
+     */
+    static getTemplateTree(globString, relativeTo) {
+
+        const files = docsHelpers.getRelativePaths(globString, relativeTo);
+
+        return files.reduce((tree, file) => {
+            const path = file.split(sep);
+            const key = path[0]
+                .replace('.njk', '')
+                .replace(/[_-]/g, ' ');
+            const name = path[path.length - 1]
+                .replace('.njk', '')
+                .replace(/[_-]/g, ' ');
+
+            tree[key] = tree[key] || {};
+            tree[key].variations = tree[key].variations || [];
+            tree[key].variations.push({ url: file, name: name });
+
+            return tree;
+
+        }, {});
+    }
+
+    /**
      * Get the component tree
      * @param {string} globString - glob pattern for the component files
      * @param {string} relativeTo - dir containing the files in globString


### PR DESCRIPTION
As discussed during the guild meeting, template and component listings are now fully recursive.

- The [index template](73/files#diff-9e77f4d290a8e2f1e1611701e360aea2) has been greatly simplified, only taking in the generated data structures for templates and components and calling a single recursive macro for generating the tree.
- [`docHelpers.js`](73/files#diff-9530f5b2288e828561d192f282e88a65):
  - A new generic directory tree walking function (`getTree`) has been introduced for generating the template and component data structures, which takes a configuration object to handle the differences between the template and component data structures.
  - Globbing has been removed in favour of directory tree walking because a flat data structure isn't useful anymore when the goal is to produce a tree structure.
  - The two previous tree generator functions, `getTemplateTree` and `getComponentTree`, have been re-purposed to act as convenience methods for passing configuration to the new `getTree` function.
- [`docs.js`](73/files#diff-2720315124f3980201587165264512c6) had its template and component tree generator calls simplified because we're no longer globbing.

![screenshot_10](https://user-images.githubusercontent.com/1983780/33375349-ef4219b0-d509-11e7-98ee-568a23b94c4b.png)

Fixes #52 