### PR TITLE
Add support for loading JSON in templates

### DIFF
--- a/config.js
+++ b/config.js
@@ -48,7 +48,8 @@ module.exports = {
             component: 'component-detail.njk',
             preview: 'component-preview.njk',
             components: `${base.src}/components`,
-            componentsAll: `${base.src}/components/**/*.yml`
+            componentsAll: `${base.src}/components/**/*.yml`,
+            componentsData: `${base.src}/components/**/*.json`
         },
         dist: {
             base: base.dist,
@@ -84,7 +85,8 @@ module.exports = {
             layout: `${base.src}/layout/*.njk`,
             layoutDir: `${base.src}/layout`,
             components: `${base.src}/components/**/*.njk`,
-            componentsDir: `${base.src}/components`
+            componentsDir: `${base.src}/components`,
+            componentsData: `${base.src}/components/**/*.json`
         },
         dist: {
             base: `${base.dist}/templates`

--- a/config.js
+++ b/config.js
@@ -10,6 +10,11 @@ const base = {
 };
 
 module.exports = {
+    base: {
+        src: base.src,
+        dist: base.dist,
+        docs: base.docs,
+    },
 
     browsersync: {
         server: {
@@ -82,6 +87,7 @@ module.exports = {
         src: {
             templates: `${base.src}/templates/**/*.njk`,
             templatesDir: `${base.src}/templates`,
+            templatesData: `${base.src}/templates/**/*.json`,
             layout: `${base.src}/layout/*.njk`,
             layoutDir: `${base.src}/layout`,
             components: `${base.src}/components/**/*.njk`,

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "gulp-changed": "^3.1.0",
     "gulp-clean-css": "^3.4.2",
     "gulp-eslint": "^4.0.0",
+    "gulp-data": "^1.3.1",
     "gulp-ext-replace": "^0.3.0",
     "gulp-filter": "^5.0.1",
     "gulp-if": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "marked": "^0.3.7",
     "mkdirp": "^0.5.1",
     "moment-timezone": "^0.5.14",
+    "nunjucks-includeData": "0.0.9",
     "require-globify": "^1.4.1",
     "run-sequence": "^2.2.0",
     "stylelint-config-standard": "^18.0.0",

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ A custom Nunjucks tag is available as a convenience for loading external JSON da
 {% component 'component-name' %}
 ```
 
-If the component has an accompanying, eponymous JSON file, its contents will be loaded and provided automatically, scoped to just the component.
+If the component has an accompanying JSON file with the same name, its contents will be loaded and provided automatically, scoped to just the component.
 
 You can also augment the data set by providing a POJO (Plain Old JavaScript Object) as the second parameter:
 ```

--- a/readme.md
+++ b/readme.md
@@ -10,13 +10,13 @@
 3. Done! You can now start your development server.
 
 ## How to: Configure bundles
-By default, the boilerplate uses Browserify to bundle all direct childs of the `/src/static/js` in their own bundle. To import a whole directory into your bundle, make it importable via an index.js file: 
+By default, the boilerplate uses Browserify to bundle all direct childs of the `/src/static/js` in their own bundle. To import a whole directory into your bundle, make it importable via an index.js file:
 ```
 export default require('./**/!(*.Spec).js', { mode: 'hash', resolve: ['reduce', 'strip-ext'] });
 ```
 
 ## How to: Including external dependencies
-To include external dependencies in your procect, you can either install them as runtime dependency using `npm i --save` or import them directly from a vendor folder. 
+To include external dependencies in your procect, you can either install them as runtime dependency using `npm i --save` or import them directly from a vendor folder.
 
 ## How to: Run ConditionerJS instead of Vanilla
 if you want to run conditioner:
@@ -76,7 +76,7 @@ implementation: Implementation instructions
 Note that `demo` should at least contain `{}` as this gets replaced with the component's HTML.
 The component is rendered for each `{}` you provide within the demo parameter.
 
-Components can be nested either with or without a sub-folder. Currently folders can only be nested one level deep.
+Components can be nested either with or without a sub-folder. Sub-folders can go to any depth.
 ```
 nav/
   nav.njk
@@ -87,3 +87,43 @@ nav/
     footerNav.njk
     footerNav.yml
 ```
+
+### Component tag
+A custom Nunjucks tag is available as a convenience for loading external JSON data into a component:
+```
+{% component 'component-name' %}
+```
+
+If the component has an accompanying, eponymous JSON file, its contents will be loaded and provided automatically, scoped to just the component.
+
+You can also augment the data set by providing a POJO (Plain Old JavaScript Object) as the second parameter:
+```
+{% component 'component-name', { cookies: '… are delicious!' } %}
+```
+
+This is especially useful for overriding the default data for a component with template data:
+```
+{% component 'component-name', componentName %}
+```
+… where `componentName` is an object from the template's data set.
+
+Finally, you can also provide an alternative data source as the second parameter — this is great for component variations, for example. First, the component directory is looked in for the provided path:
+```
+{% component 'component-name', 'component-name-variation.json' %}
+```
+
+After that, the path is looked for from the project base:
+```
+{% component 'component-name', '/data/my-custom-data.json' %}
+```
+
+If the component resides in a nested folder, simply write out the path to it. For example:
+```
+{% component 'my-sub-folder/component-name' %}
+```
+
+## Templates
+Like components, templates can be nested inside of sub-folders to any depth. Also like components, templates that have an accompanying JSON file will have it automatically loaded and provided as template data.
+
+## includeData plugin
+In case the above isn't enough at some point, the [includeData plugin](https://github.com/VincentLeung/nunjucks-includeData) is available for even more freedom in including data from external JSON files. Refer to its documentation for details.

--- a/src/components/list/list-waffles.json
+++ b/src/components/list/list-waffles.json
@@ -1,0 +1,3 @@
+{
+	"items": ["Brussels waffle", "Lìege waffle", "Stroopwafel", "Gofri"]
+}

--- a/src/components/list/list.json
+++ b/src/components/list/list.json
@@ -1,0 +1,3 @@
+{
+	"items": ["Item 1", "Item 2", "Item 3"]
+}

--- a/src/components/list/list.njk
+++ b/src/components/list/list.njk
@@ -1,0 +1,5 @@
+<ul>
+	{%- for item in items -%}
+	<li>{{ item }}</li>
+	{%- endfor -%}
+</ul>

--- a/src/components/list/list.yml
+++ b/src/components/list/list.yml
@@ -1,0 +1,2 @@
+title: List
+description: List component for demonstrational purposes

--- a/src/components/nav/nav.json
+++ b/src/components/nav/nav.json
@@ -1,5 +1,3 @@
 {
-	"nav": {
-		"content": "Navigation"
-	}
+	"content": "Navigation"
 }

--- a/src/components/nav/nav.json
+++ b/src/components/nav/nav.json
@@ -1,0 +1,5 @@
+{
+	"nav": {
+		"content": "Navigation"
+	}
+}

--- a/src/components/nav/nav.njk
+++ b/src/components/nav/nav.njk
@@ -1,3 +1,3 @@
 <nav data-module="nav/Nav">
-    Navigation
+	{{ nav.content }}
 </nav>

--- a/src/components/nav/nav.njk
+++ b/src/components/nav/nav.njk
@@ -1,3 +1,3 @@
 <nav data-module="nav/Nav">
-	{{ nav.content }}
+	{{ content }}
 </nav>

--- a/src/templates/home.json
+++ b/src/templates/home.json
@@ -1,6 +1,7 @@
 {
-	"home": {
-		"title": "I'm a title",
-		"body": "This codebase is a blueprint environment to quick start new front-end projects. It contains an HTTP server via Browsersync, Nunjucks, SCSS, Babel and a Gulp build script to manage it all."
+	"title": "I'm a title",
+	"body": "This codebase is a blueprint environment to quick start new front-end projects. It contains an HTTP server via Browsersync, Nunjucks, SCSS, Babel and a Gulp build script to manage it all.",
+	"list": {
+		"items": ["Cherry pie", "Apple pie", "Quiche"]
 	}
 }

--- a/src/templates/home.json
+++ b/src/templates/home.json
@@ -1,0 +1,6 @@
+{
+	"home": {
+		"title": "I'm a title",
+		"body": "This codebase is a blueprint environment to quick start new front-end projects. It contains an HTTP server via Browsersync, Nunjucks, SCSS, Babel and a Gulp build script to manage it all."
+	}
+}

--- a/src/templates/home.njk
+++ b/src/templates/home.njk
@@ -1,13 +1,22 @@
 {% extends '../layout/default.njk' %}
-{% includeData './home.json' %}
-{% includeData '../components/nav/nav.json' %}
 
 {% block body %}
     <div class="wrapper">
-        {% include '../components/nav/nav.njk' %}
+        {% component 'nav' %}
         <main>
-            <h1>{{ home.title }}</h1>
-            <p>{{ home.body }}</p>
+            <h1>{{ title }}</h1>
+            <p>{{ body }}</p>
+            <h2>List component with default data</h2>
+            {% component 'list' %}
+            <h2>List component with alternate data source path</h2>
+            <p>Some types of waffles:</p>
+            {% component 'list', 'list-waffles.json' %}
+            <h2>List component with data provided by template data</h2>
+            <p>Some types of pies:</p>
+            {% component 'list', list %}
+            <h2>List component with inline data</h2>
+            <p>Some types of cookies:</p>
+            {% component 'list', { items: ['Chocolate chip cookie', 'Animal cracker', 'Brownie'] } %}
         </main>
     </div>
 {% endblock %}

--- a/src/templates/home.njk
+++ b/src/templates/home.njk
@@ -1,11 +1,13 @@
 {% extends '../layout/default.njk' %}
+{% includeData './home.json' %}
+{% includeData '../components/nav/nav.json' %}
 
 {% block body %}
     <div class="wrapper">
         {% include '../components/nav/nav.njk' %}
         <main>
-            <h1>I'm a title</h1>
-            <p>This codebase is a blueprint environment to quick start new front-end projects. It contains an HTTP server via Browsersync, Nunjucks, SCSS, Babel and a Gulp build script to manage it all.</p>
+            <h1>{{ home.title }}</h1>
+            <p>{{ home.body }}</p>
         </main>
     </div>
 {% endblock %}

--- a/src/templates/home.njk
+++ b/src/templates/home.njk
@@ -6,14 +6,18 @@
         <main>
             <h1>{{ title }}</h1>
             <p>{{ body }}</p>
+
             <h2>List component with default data</h2>
             {% component 'list' %}
+
             <h2>List component with alternate data source path</h2>
             <p>Some types of waffles:</p>
             {% component 'list', 'list-waffles.json' %}
+
             <h2>List component with data provided by template data</h2>
             <p>Some types of pies:</p>
             {% component 'list', list %}
+
             <h2>List component with inline data</h2>
             <p>Some types of cookies:</p>
             {% component 'list', { items: ['Chocolate chip cookie', 'Animal cracker', 'Brownie'] } %}

--- a/tasks/docs.js
+++ b/tasks/docs.js
@@ -88,6 +88,7 @@ gulp.task('docs-watch', cb => {
     const watching = [
         config.docs.src.index,
         config.docs.src.componentsAll,
+        config.docs.src.componentsData,
         config.html.src.templates,
         config.html.src.layout,
         config.html.src.components

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -39,7 +39,7 @@ gulp.task('html-watch', cb => {
     ], () => gulp.start(['html'], cb));
 });
 
-// If a template has an eponymous .json file in the same location, load it as a data source
+// If a template has a .json file with the same name in the same location, load it as a data source
 const getDataForFile = file => {
     try {
         return JSON.parse(fs.readFileSync(file.path.replace('.njk', '.json')))

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -27,5 +27,10 @@ gulp.task('html', () => {
  */
 gulp.task('html-watch', cb => {
     const paths = config.src;
-    watch([paths.templates, paths.layout, paths.components], () => gulp.start(['html'], cb));
+    watch([
+        paths.templates,
+        paths.layout,
+        paths.components,
+        paths.componentsData
+    ], () => gulp.start(['html'], cb));
 });

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -4,12 +4,15 @@ import gulp from 'gulp';
 import render from 'gulp-nunjucks-render';
 import watch from 'gulp-watch';
 import envManager from './util/envManager';
+import data from 'gulp-data';
+import fs from 'fs';
 
 /**
  * Task: HTML Compile
  */
 gulp.task('html', () => {
     return gulp.src(config.src.templates)
+        .pipe(data(getDataForFile))
         .pipe(render({
             path: [
                 config.src.templatesDir,
@@ -29,8 +32,18 @@ gulp.task('html-watch', cb => {
     const paths = config.src;
     watch([
         paths.templates,
+        paths.templatesData,
         paths.layout,
         paths.components,
         paths.componentsData
     ], () => gulp.start(['html'], cb));
 });
+
+// If a template has an eponymous .json file in the same location, load it as a data source
+const getDataForFile = file => {
+    try {
+        return JSON.parse(fs.readFileSync(file.path.replace('.njk', '.json')))
+    } catch (error) {
+        return {}
+    }
+}

--- a/tasks/util/docHelpers.js
+++ b/tasks/util/docHelpers.js
@@ -41,11 +41,17 @@ class docsHelpers {
     static renderComponent(content, file) {
         const environment = docsHelpers.createEnvironment();
         const yml = yaml.load(content);
-        const locals = Object.assign(yml.data || '{}', { baseUri: config.html.baseUri });
         let sample = '';
+        let sampleData;
 
         try {
-            sample = htmlBeautify(environment.render(file.path.replace('.yml', '.njk'), locals));
+            sampleData = JSON.parse(fs.readFileSync(file.path.replace('.yml', '.json')))
+        } catch (error) {
+            sampleData = {}
+        }
+
+        try {
+            sample = htmlBeautify(environment.render(file.path.replace('.yml', '.njk'), { ...sampleData, baseUri: config.html.baseUri }));
         } catch (error) {
             global.console.log(error);
         }
@@ -71,11 +77,17 @@ class docsHelpers {
     static renderComponentDemo(content, file) {
         const environment = docsHelpers.createEnvironment();
         const yml = yaml.load(content);
-        const locals = Object.assign(yml.data || '{}', { baseUri: config.html.baseUri });
         let demo = '';
+        let data;
 
         try {
-            demo = environment.render(file.path.replace('.yml', '.njk'), locals);
+            data = JSON.parse(fs.readFileSync(file.path.replace('.yml', '.json')))
+        } catch (error) {
+            data = {}
+        }
+
+        try {
+            demo = environment.render(file.path.replace('.yml', '.njk'), { ...data, baseUri: config.html.baseUri });
             demo = (yml.demo || '{}').replace(/\{\}/g, demo);
         } catch (error) {
             global.console.log(error);

--- a/tasks/util/envManager.js
+++ b/tasks/util/envManager.js
@@ -1,3 +1,6 @@
+import includeData from 'nunjucks-includeData'
+
 module.exports = env => {
     env.addFilter('isNumber', input => typeof input === 'number');
+    includeData.install(env);
 };

--- a/tasks/util/envManager.js
+++ b/tasks/util/envManager.js
@@ -1,6 +1,13 @@
 import includeData from 'nunjucks-includeData'
+import { ComponentTag } from './nunjucks-extensions'
 
 module.exports = env => {
-    env.addFilter('isNumber', input => typeof input === 'number');
+    // IncludeData plugin
     includeData.install(env);
+
+    // Extensions
+    env.addExtension('component', new ComponentTag(env));
+
+    // Filters
+    env.addFilter('isNumber', input => typeof input === 'number');
 };

--- a/tasks/util/nunjucks-extensions.js
+++ b/tasks/util/nunjucks-extensions.js
@@ -1,0 +1,83 @@
+import config from '../../config'
+import { nunjucks } from 'gulp-nunjucks-render'
+import fs from 'fs'
+
+/**
+ * Custom tag 'component' that attempts to load a component's accompanying JSON data file, if any, and pass the data to the component.
+ * Use as `{% component 'foo' %}` instead of `{% include '../components/foo/foo.html' %}`
+ * A second, optional argument is supported. If it's a string, it specifies an alternate data source, e.g.:
+ * `{% component 'foo', 'data/foo.json' %}`
+ * This path will be looked for in the component directory itself first, then it will try to find it from the project base.
+ * It can also be an object to augment the data set, e.g.:
+ * `{% component 'foo', { color: 'hotpink' } %}`
+ */
+export const ComponentTag = function(env) {
+	this.tags = ['component']
+
+	this.parse = (parser, nodes, lexer) => {
+		const token = parser.nextToken()
+		const args = parser.parseSignature(null, true)
+		parser.advanceAfterBlockEnd(token.value)
+
+		return new nodes.CallExtension(this, 'run', args)
+	}
+
+	this.run = (context, componentIdentifier, dataPathOrData) => {
+		const component = getComponentParts(componentIdentifier)
+		const dataPath = getDataPath(dataPathOrData, component)
+		const componentStem = `${component.base ? component.base + '/' : ''}${component.name}/${component.name}`
+		let json = {}
+
+		if (dataPath) {
+			try {
+				json = JSON.parse(fs.readFileSync(dataPath))
+			} catch (error) {
+				console.log(error)
+			}
+		}
+
+		const data = typeof dataPathOrData === 'string' ? json : { ...json, ...dataPathOrData }
+
+		return new nunjucks.runtime.SafeString(env.render(`${componentStem}.njk`, data))
+	}
+
+	/**
+	 **	Split the passed-in component identifier into its full path, base, and name
+	 **	Simple case: 'my-component' ⇒ 'my-component/my-component.{njk,json,yml}'
+	 **	Complex case: 'one/two/my-component' ⇒ 'one/two/my-component/my-component.{njk,json,yml}'
+	 **	@param {String} componentIdentifier - the requested component
+	 **	@returns {Object} - signature: { base: full path to component dir, base: requested path minus component name itself, name: component name }
+	 */
+	const getComponentParts = componentIdentifier => {
+		const parts = componentIdentifier.split('/')
+		const name = parts.pop()
+		const base = parts.join('/')
+		const path = `${config.html.src.componentsDir}${base ? '/' + base : ''}/${name}`
+
+		return { path, base, name }
+	}
+
+	/**
+	 **	Determine the path to the data file to be loaded, if any
+	 **	@param {String|Object} dataPathOrData - a path to a JSON file, or a POJO
+	 **	@param {Object} component - component info object from `getComponentParts`
+	 **	@returns {String|undefined} - path to data file, or undefined if none found
+	 */
+	const getDataPath = (dataPathOrData, component) => {
+		let path
+		if (typeof dataPathOrData === 'string') {
+			// Check if requested path exists in component's directory
+			path = `${component.path}/${dataPathOrData}`
+			if (fs.existsSync(path)) return path
+			// Then, check if requested path exists from the project's base dir (e.g. `/data/foo.json`)
+			path = `${config.base.src}/${dataPathOrData}`
+			if (fs.existsSync(path)) return path
+		} else {
+			// Try to find eponymous data file in component's directory
+			path = `${component.path}/${component.name}.json`
+			if (fs.existsSync(path)) return path
+		}
+
+		return
+	}
+}

--- a/tasks/util/nunjucks-extensions.js
+++ b/tasks/util/nunjucks-extensions.js
@@ -73,7 +73,7 @@ export const ComponentTag = function(env) {
 			path = `${config.base.src}/${dataPathOrData}`
 			if (fs.existsSync(path)) return path
 		} else {
-			// Try to find eponymous data file in component's directory
+			// Try to find data file in component's directory with same name
 			path = `${component.path}/${component.name}.json`
 			if (fs.existsSync(path)) return path
 		}


### PR DESCRIPTION
**Update 16 march**: Based on feedback during the last guild meeting, and from some folks individually, several options have been added:
 * A custom 'component' Nunjucks tags that automatically loads a component's eponymous JSON file if it has one, with an optional second argument for specifying an alternate data source path or object;
 * Automatic loading of JSON data from a template's eponymous JSON file, if it has one;
 * Documentation was updated to describe all new options and configurations;
 * A new demo component was added with various configurations to demonstrate the new functionality. 

Full details of functionality is described in the updated readme: https://github.com/colin-aarts/frontend-bootstrap/blob/bf6ea0f48ed556fde495265b35721f07719a5953/readme.md#how-to-component-library

**Old PR description**

 * `nunjucks-includeData` plugin allows loading of arbitrary JSON files from templates;
 * Components with a JSON file in their directory bearing the component's name will be automatically loaded in the component's documentation;
 * Replaced sample content in home.njk and nav.njk with data from JSON files.

This PR partially satisfies #58 by adding support for loading data from JSON files in Nunjucks (@ericweerstra delegated this to me 😉). It includes code from Eric and @peeke; I'm mostly just taking care of the PR itself.

This PR makes no assumptions about where exactly you want to store this JSON data (although a JSON file in a component's directory will be automatically loaded in the docs if it exists and has the same name) as that still seems to be topic of discussion in #58 . A separate PR can address that later.

For demonstrational purposes, this PR includes a JSON file for the `Nav` component and one for use in the `home.njk` template. The latter file is placed in the `templates` directory, directly alongside the template file, but that's flexible. This also means that no watcher for these JSON files is added in this PR; that will have to be part of whatever future PR addresses the location of such data files. If you want hot reloading support until such a time, you can easily do that in your project. Simply add the paths to your config, e.g.:
```js
html: {
    src: {
        templates: `${base.src}/templates/**/*.njk`,
        templatesDir: `${base.src}/templates`,
        templatesData: `${base.src}/templates/**/*.json`,
        layout: `${base.src}/layout/*.njk`,
        layoutDir: `${base.src}/layout`,
        components: `${base.src}/components/**/*.njk`,
        componentsDir: `${base.src}/components`,
        componentsData: `${base.src}/components/**/*.json`,
```
… and include these paths in the watch task.

Edit: note that this removes support for including data from a component's yaml file through the `data` property, but I believe that was undocumented anyway.