### PR TITLE
Fix initial component initialization

### DIFF
--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -9,7 +9,7 @@ const ready = () => {
     return new Promise(resolve => document.addEventListener('DOMContentLoaded', resolve));
 };
 
-ready().then(initializeComponents(document));
+ready().then(() => initializeComponents(document));
 
 // // If you want to use conditioner instead:
 //


### PR DESCRIPTION
This PR fixes the initial (domready) component initialization. Currently, the `then` resolve callback is passed the result of `initializeComponents(document)` (`undefined`) instead of an actual callback which executes that function.

This causes component initialization to proceed immediately, regardless of actual domready status. Elements with modules attached that aren't ready yet will simply never be initialized.