### PR TITLE
Added TravisCI configuration and badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+
+os:
+  - linux
+  - osx
+
+node_js:
+  - lts/*
+
+script:
+  - npm run lint
+  - npm run test
+  - npm run dist

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 ![Logo](frontend-boilerplate.svg)
 
+[![Build Status](https://travis-ci.org/mirabeau-nl/frontend-boilerplate.svg?branch=master)](https://travis-ci.org/mirabeau-nl/frontend-boilerplate-cli)
+
 [We're hiring!](https://www.werkenbijmirabeau.nl/en) ✨
 
 This project is a highly opinionated boilerplate that can be used to quickly kickstart a new web development project. It's built on modern tools such as Gulp, Babel, and Browsersync. Using the boilerplate will help you stay productive by eliminating bikeshedding and by encouraging testing.


### PR DESCRIPTION
In this PR I've added TravisCI configuration. I've chosen to run tests on linux & macOS against the Node.js LTS, but not the current Node.js Stable because it breaks. The tasks ran are `npm run dist` and `npm run test`, preceded by `npm i`.

I've also added a readme badge which points to the build/test results page at Travis:
https://travis-ci.org/mirabeau-nl/frontend-boilerplate