### PR TITLE
Fixed a regression bug where the js-browserify task would fail silently

### DIFF
--- a/tasks/js.js
+++ b/tasks/js.js
@@ -92,8 +92,8 @@ gulp.task('js-browserify', done => {
 
     const tasks = files
       .map(bundleFile)
-      .map(bundler => new Promise(resolve => bundler.on('end', resolve)))
+      .map(bundle => new Promise(resolve => bundle.on('finish', resolve)))
 
-    Promise.all(tasks).then(done)
+    Promise.all(tasks).then(() => done()).catch(done)
   })
 })


### PR DESCRIPTION
The previous PR had an issue where the js-browserify would fail silently instead of finishing.