### PR TITLE
Improve component data flexibility

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -179,6 +179,12 @@ After that, the path is looked for from the project base:
 {% component 'component-name', '/data/my-custom-data.json' %}
 ```
 
+You can also provide both a data path and inline data:
+
+```
+{% component 'component-name', 'component-name-variation.json', { override: 'something' } %}
+```
+
 If the component resides in a nested folder, simply write out the path to it. For example:
 
 ```

--- a/src/templates/home.njk
+++ b/src/templates/home.njk
@@ -21,6 +21,10 @@
     <h2>List component with inline data</h2>
     <p>Some types of cookies:</p>
     {% component 'list', { items: ['Chocolate chip cookie', 'Animal cracker', 'Brownie'] } %}
+
+    <h2>List component with alternate data source path and inline data override</h2>
+    <p>Some types of waffles:</p>
+    {% component 'list', 'list-waffles.json', { items: ["There's nothing here anymore, I've eaten all your waffles!"] } %}
   </main>
 </div>
 {% endblock %}

--- a/tasks/util/nunjucks-extensions.js
+++ b/tasks/util/nunjucks-extensions.js
@@ -93,7 +93,7 @@ export const ComponentTag = function(env) {
     return new nodes.CallExtension(this, 'run', args)
   }
 
-  this.run = (context, componentIdentifier, dataPathOrData) => {
+  this.run = (context, componentIdentifier, dataPathOrData, data) => {
     const component = getComponentParts(componentIdentifier)
     const dataPath = getDataPath(dataPathOrData, component)
     const componentStem = `${component.base ? `${component.base}/` : ''}${
@@ -109,11 +109,11 @@ export const ComponentTag = function(env) {
       }
     }
 
-    const data =
-      typeof dataPathOrData === 'string' ? json : { ...json, ...dataPathOrData }
+    const inlineData =
+      typeof dataPathOrData === 'string' ? data : dataPathOrData
 
     return new nunjucks.runtime.SafeString(
-      env.render(`${componentStem}.njk`, data)
+      env.render(`${componentStem}.njk`, { ...json, ...inlineData })
     )
   }
 }


### PR DESCRIPTION
This PR builds upon the 'component data' functionality by allowing you to pass inline data in addition to a reference to a data file (json), instead of being able to only do one or the other:

```{% component 'component-name', 'some-data.json', { override: 'something' } %}```

Changes:
 * Add support for passing inline data in addition to a file reference
 * Update readme to reflect this