### PR TITLE
feature/browsersync-config: Added handling optional "--https" argument to start browsersync in https mode

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,7 +3,7 @@ import pkg from './package.json'
 
 dotenv.load({ silent: true })
 
-const { env } = process
+const { argv, env } = process
 
 const base = {
   src: './src',
@@ -24,7 +24,8 @@ module.exports = {
     },
     open: false,
     ui: false,
-    notify: false
+    notify: false,
+    https: argv.includes('--https')
   },
 
   clean: {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "Bram Swier <bswier@mirabeau.nl> (https://www.mirabeau.nl/)",
     "Marius de Corte <mdecorte@mirabeau.nl> (http://mariusdecorte.nl/)",
     "Cosmin Epureanu <cosmin.epureanu@gmail.com> (http://cosminepureanu.com/)",
-    "Colin Aarts <hello@colinaarts.com> (https://colinaarts.com)"
+    "Colin Aarts <hello@colinaarts.com> (https://colinaarts.com)",
+    "Dave Bitter <dbitter@mirabeau.nl> (https://davebitter.com)"
   ],
   "readmeFilename": "readme.md",
   "license": "BSD-3-Clause",

--- a/readme.md
+++ b/readme.md
@@ -8,17 +8,23 @@ This project is a highly opinionated boilerplate that can be used to quickly kic
 
 ## 📖 Table of contents
 
-* [Features](#features)
-* [Quickstart guide](#-quickstart)
-* [Getting started guide](#-getting-started)
-  * [Set up development environment](#set-up-your-development-environment)
+* [📖 Table of contents](#%F0%9F%93%96-table-of-contents)
+* [💫 Features](#%F0%9F%92%AB-features)
+* [🚀 Quickstart](#%F0%9F%9A%80-quickstart)
+* [➡️ Getting started](#%E2%9E%A1%EF%B8%8F-getting-started)
+  * [Set up your development environment](#set-up-your-development-environment)
   * [Creating new components](#creating-new-components)
   * [Creating new templates](#creating-new-templates)
   * [Linting and testing](#linting-and-testing)
   * [Building and uploading](#building-and-uploading)
-* [Extending the boilerplate](#extending-the-boilerplate)
-* [Using the component library](#-using-the-component-library)
-* [Using the custom component Nunjucks tag](#-using-the-custom-nunjucks-component-tag)
+* [🕹 Extending the boilerplate](#%F0%9F%95%B9-extending-the-boilerplate)
+  * [How to: Configure bundles](#how-to-configure-bundles)
+  * [How to: Including external dependencies](#how-to-including-external-dependencies)
+  * [How to: Run ConditionerJS💆‍♀️ instead of Vanilla](#how-to-run-conditionerjs%F0%9F%92%86%E2%80%8D%E2%99%80%EF%B8%8F-instead-of-vanilla)
+* [📚 Using the component library](#%F0%9F%93%9A-using-the-component-library)
+* [🏷 Using the custom Nunjucks component tag](#%F0%9F%8F%B7-using-the-custom-nunjucks-component-tag)
+  * [Templates](#templates)
+  * [includeData plugin](#includedata-plugin)
 
 ## 💫 Features
 
@@ -54,6 +60,8 @@ This boilerplate utilizes Gulp heavily to automate tasks and manage frontend dep
    npm install
    ```
 4. Done! You can now start your development server by running `npm run dev`. This command will start a local server, located at `http://localhost:3000`.
+
+Note: optionally, you can run the development server in https mode without certificates by passing the `--https` flag. If you have to use certificates you can pass them in `config.js` under 'browsersync'.
 
 It's important to realize that this boilerplate distinguishes between `components` and `templates`. A component (located in `src/components`) is just that, a component. It could be a menu, or a list of items. A template (located in `src/templates`) is a collection of components.
 


### PR DESCRIPTION
I added an optional `--https` flag to start browsersync in https mode.

Example:
`yarn dev` - starts dev environment in http mode
`yarn dev --https` - starts dev environment in https mode