### PR TITLE
Added root folder copy task

### DIFF
--- a/config.js
+++ b/config.js
@@ -152,6 +152,11 @@ module.exports = {
     eslintAutofix: false
   },
 
+  public: {
+    src: `${base.src}/public/**/*`,
+    dist: `${base.dist}`
+  },
+
   upload: {
     src: {
       all: `${base.dist}/**`

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -14,6 +14,7 @@ import { fonts, fontsWatch } from './tasks/fonts'
 import { js, jsLint, jsTest } from './tasks/js'
 import { mock, mockWatch } from './tasks/mock'
 import { fileUpload } from './tasks/upload'
+import { publicFiles, publicFilesWatch } from './tasks/publicFiles'
 import { githooks } from './tasks/githooks'
 import { zip } from './tasks/zip'
 
@@ -29,6 +30,7 @@ function dev(cb) {
       imgWatch,
       cssWatch,
       fontsWatch,
+      publicFilesWatch,
       mockWatch
     )
   )(cb)
@@ -38,10 +40,18 @@ function dist(cb) {
   const { argv } = process
 
   if (argv.includes('--static')) {
-    return series(clean, parallel(html, img, css, fonts, js), moveTemplatesToRoot)(cb)
+    return series(
+      clean,
+      parallel(html, img, css, fonts, publicFiles, js),
+      moveTemplatesToRoot
+    )(cb)
   }
 
-  return series(clean, parallel(docs, html, img, css, fonts, mock, js), zip)(cb)
+  return series(
+    clean,
+    parallel(docs, html, img, css, fonts, publicFiles, mock, js),
+    zip
+  )(cb)
 }
 
 function codequality(cb) {
@@ -64,5 +74,6 @@ export {
   dist,
   codequality,
   test,
+  publicFiles,
   upload
 }

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -25,8 +25,7 @@ const getDataForFile = file => {
  * @returns {NodeJS.WritableStream}
  */
 function copyTemplates() {
-  return src([`${config.dist.base}/**/*`])
-    .pipe(dest(base.dist))
+  return src([`${config.dist.base}/**/*`]).pipe(dest(base.dist))
 }
 
 /**
@@ -81,4 +80,5 @@ export function htmlWatch() {
  * @param {Object} cb - Gulp callback function
  * @returns {Object}
  */
-export const moveTemplatesToRoot = cb => series(copyTemplates, delTemplatesFolder)(cb)
+export const moveTemplatesToRoot = cb =>
+  series(copyTemplates, delTemplatesFolder)(cb)

--- a/tasks/publicFiles.js
+++ b/tasks/publicFiles.js
@@ -1,0 +1,20 @@
+import { public as config } from '../config'
+import { src, dest, watch, series } from 'gulp'
+import { reload } from 'browser-sync'
+
+/**
+ * Task: Copy public
+ * @returns {NodeJS.WritableStream}
+ */
+export function publicFiles() {
+  return src(config.src)
+    .pipe(dest(config.dist))
+    .pipe(reload({ stream: true }))
+}
+
+/**
+ * Task: public watch
+ */
+export function publicFilesWatch() {
+  watch(config.src.public, series(publicFiles))
+}


### PR DESCRIPTION
Currently, we are not able to copy files to the root of the dist. This task copies files in the `src/public` folder to the root of the dist folder.

Note that I can't name the task `public` to follow the naming pattern since this is a property in JS.
