### PR TITLE
Format code in accordance with prettier formatting rules

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -38,7 +38,11 @@ function dist(cb) {
   const { argv } = process
 
   if (argv.includes('--static')) {
-    return series(clean, parallel(html, img, css, fonts, js), moveTemplatesToRoot)(cb)
+    return series(
+      clean,
+      parallel(html, img, css, fonts, js),
+      moveTemplatesToRoot
+    )(cb)
   }
 
   return series(clean, parallel(docs, html, img, css, fonts, mock, js), zip)(cb)

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -25,8 +25,7 @@ const getDataForFile = file => {
  * @returns {NodeJS.WritableStream}
  */
 function copyTemplates() {
-  return src([`${config.dist.base}/**/*`])
-    .pipe(dest(base.dist))
+  return src([`${config.dist.base}/**/*`]).pipe(dest(base.dist))
 }
 
 /**
@@ -81,4 +80,5 @@ export function htmlWatch() {
  * @param {Object} cb - Gulp callback function
  * @returns {Object}
  */
-export const moveTemplatesToRoot = cb => series(copyTemplates, delTemplatesFolder)(cb)
+export const moveTemplatesToRoot = cb =>
+  series(copyTemplates, delTemplatesFolder)(cb)


### PR DESCRIPTION
Isolate code style changes that get done by pre-commit githook on several lines, to bring codebase in line with prettier formatting rules, so these changes wouldn't smuggle themselves with other code changes