### PR TITLE
fix(component): Fixed component data override not being added when pa…

### DIFF
--- a/tasks/js.js
+++ b/tasks/js.js
@@ -88,7 +88,12 @@ export function jsLint() {
       })
     )
     .pipe(eslint.format())
-    .pipe(gulpif(isFixed, dest(file => file.base)))
+    .pipe(
+      gulpif(
+        isFixed,
+        dest(file => file.base)
+      )
+    )
     .pipe(eslint.failAfterError())
 }
 

--- a/tasks/util/nunjucks-extensions.js
+++ b/tasks/util/nunjucks-extensions.js
@@ -93,7 +93,7 @@ export const ComponentTag = function(env) {
     return new nodes.CallExtension(this, 'run', args)
   }
 
-  this.run = (context, componentIdentifier, dataPathOrData, data) => {
+  this.run = (context, componentIdentifier, dataPathOrData, dataOverride) => {
     const component = getComponentParts(componentIdentifier)
     const dataPath = getDataPath(dataPathOrData, component)
     const componentStem = `${component.base ? `${component.base}/` : ''}${
@@ -110,7 +110,9 @@ export const ComponentTag = function(env) {
     }
 
     const inlineData =
-      typeof dataPathOrData === 'string' ? data : dataPathOrData
+      typeof dataPathOrData === 'string'
+        ? dataOverride
+        : { ...dataPathOrData, ...dataOverride }
 
     return new nunjucks.runtime.SafeString(
       env.render(`${componentStem}.njk`, { ...json, ...inlineData })


### PR DESCRIPTION
This fixes the data override bug in the component tag

An example from the README:
```njk
{% component 'component-name', 'component-name-variation.json', { override: 'something' } %}
```
In this case, the override would work indeed. But, when passing an object instead of a path (e.g. 'component-name-variation.json' -> { foo: 'bar' }), the override object would not be passed to the component. I've added the override object for this usecase.

Next to that, I renamed the variable `data` to `overrideData` to make the code easier to understand.
