### PR TITLE
Remove Moment.js in favour of plain JS

### DIFF
--- a/config.js
+++ b/config.js
@@ -68,6 +68,15 @@ module.exports = {
     codeBeautifier: {
       'indent-size': 2,
       'max-preserve-newlines': 0
+    },
+    date: {
+      locale: 'en-GB',
+      options: {
+        dateStyle: 'long',
+        timeStyle: 'long',
+        timeZone: 'Europe/Amsterdam',
+        timeZoneName: 'short'
+      }
     }
   },
 

--- a/config.js
+++ b/config.js
@@ -72,6 +72,13 @@ module.exports = {
     date: {
       locale: 'en-GB',
       options: {
+        // individual date components are fallback for Node < 13
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+        second: 'numeric',
         dateStyle: 'long',
         timeStyle: 'long',
         timeZone: 'Europe/Amsterdam',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10336,21 +10336,6 @@
         "xtend": "^4.0.0"
       }
     },
-    "moment": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
-      "dev": true
-    },
-    "moment-timezone": {
-      "version": "0.5.31",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
-      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
-      "dev": true,
-      "requires": {
-        "moment": ">= 2.9.0"
-      }
-    },
     "mozjpeg": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/mozjpeg/-/mozjpeg-6.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "js-beautify": "^1.10.3",
     "js-yaml": "^3.13.1",
     "marked": "^0.8.0",
-    "moment-timezone": "^0.5.28",
     "nunjucks-includeData": "0.0.9",
     "prettier": "1.19.1",
     "require-globify": "^1.4.1",

--- a/tasks/docs.js
+++ b/tasks/docs.js
@@ -1,7 +1,6 @@
 import config from '../config'
 import { src, dest, series, watch } from 'gulp'
 import render from 'gulp-nunjucks-render'
-import moment from 'moment-timezone'
 import transform from 'gulp-transform'
 import ext from 'gulp-ext-replace'
 import gulpif from 'gulp-if'
@@ -29,9 +28,11 @@ function docsRenderIndex() {
   const data = {
     templates,
     components,
-    lastUpdated: moment()
-      .tz('Europe/Amsterdam')
-      .format('DD-MM-YYYY HH:mm:ss z')
+    lastUpdated: new Date().toISOString(),
+    lastUpdatedText: new Intl.DateTimeFormat(
+      config.docs.date.locale,
+      config.docs.date.options
+    ).format(new Date())
   }
 
   const paths = [

--- a/tasks/docs.js
+++ b/tasks/docs.js
@@ -23,16 +23,17 @@ function docsRenderIndex() {
   // Grab list of templates
   const templates = helpers.getTemplateTree(config.docs.src.templates)
   const components = helpers.getComponentTree(config.docs.src.components)
+  const lastUpdated = new Date()
 
   // Data
   const data = {
     templates,
     components,
-    lastUpdated: new Date().toISOString(),
+    lastUpdated: lastUpdated.toISOString(),
     lastUpdatedText: new Intl.DateTimeFormat(
       config.docs.date.locale,
       config.docs.date.options
-    ).format(new Date())
+    ).format(lastUpdated)
   }
 
   const paths = [

--- a/tasks/docs/index.njk
+++ b/tasks/docs/index.njk
@@ -23,7 +23,7 @@
 <div class="container">
 
   <h1>Front-End Library</h1>
-  <p>Last updated: {{ lastUpdated }}</p>
+  <p>Last updated: <time datetime="{{ lastUpdated }}">{{ lastUpdatedText }}</time></p>
   <!--[[dist.zip]]-->
 
   <h2>Templates</h2>


### PR DESCRIPTION
I’m removing the dependency Moment.js and Moment-Timezone, because we don’t need it. We can use the Intl.DateTimeFormat object for quite a while now in Node.js. This change will save some disk space.

For delivery purposes, we show when the library has last been updated. This can be particularly useful for projects where we work with clients or colleagues that are in a different time zone. For extra clarity, the format will change from a mixed English/Dutch locale to British. `Last updated: 10-12-2020 13:37:00 CET` will become `Last updated: 10 December 2020 13:37:00 CET` with my change.

Configuration is available for people who need to set the correct time zone they’re working form, or when they want to change the format.