### PR TITLE
fix(docs): support for Node v15+

### DIFF
--- a/config.js
+++ b/config.js
@@ -72,17 +72,9 @@ module.exports = {
     date: {
       locale: 'en-GB',
       options: {
-        // individual date components are fallback for Node < 13
-        day: 'numeric',
-        month: 'long',
-        year: 'numeric',
-        hour: 'numeric',
-        minute: 'numeric',
-        second: 'numeric',
         dateStyle: 'long',
         timeStyle: 'long',
-        timeZone: 'Europe/Amsterdam',
-        timeZoneName: 'short'
+        timeZone: 'Europe/Amsterdam'
       }
     }
   },


### PR DESCRIPTION
In PR #133 I’ve added redundant configuration for the date style. This was to provide a fallback to Node < 13. As of Node 15 this method of providing redundant config is not permitted anymore.

In this PR I’m removing the fallback in favour of clean code; making the Boilerplate more future proof.