### PR TITLE
feature(travis): Upgrade travis to latest version to fix npm ci issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
 
 node_js:
-  - lts/*
+  - node
 
 script:
   - npm run codequality


### PR DESCRIPTION
Travis build were failing due to a bug in npm 6. By using the latest node version instead of the LTS one the checks pass again! 👍 